### PR TITLE
Fixed typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-pincode-input",
   "version": "1.2.1",
   "description": "Bootstrap jQuery widget for x-digit pincode input",
-  "main": "js/bootstrap-pincode.input.js",
+  "main": "js/bootstrap-pincode-input.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Changed to reference to the main script, it had a . in it instead of a -. 
It crashed when used with npm, it does not anymore.