### PR TITLE
Fix version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-pincode-input",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "Bootstrap jQuery widget for x-digit pincode input",
   "main": "js/bootstrap-pincode-input.js",
   "scripts": {


### PR DESCRIPTION
- Version 1.3 isn't installable. `npm` expects versions to be fully qualified. 