### PR TITLE
Attempt differentiating keys by name, not code

### DIFF
--- a/js/bootstrap-pincode-input.js
+++ b/js/bootstrap-pincode-input.js
@@ -230,18 +230,28 @@
 						
 							}else{
 								// in desktop mode, check if an number was entered
-								
-								if( !(e.keyCode == 8                                // backspace key
-										|| e.keyCode == 9							// tab key
-								        || e.keyCode == 46                          // delete key
-								        || (e.keyCode >= 48 && e.keyCode <= 57)     // numbers on keyboard
-								        || (e.keyCode >= 96 && e.keyCode <= 105))   // number on keypad
-								        ) {
-								            e.preventDefault();     // Prevent character input
-								            e.stopPropagation();  
-								            
-								    }
-								
+								try {
+									if ( !(e.key == 'Backspace'
+											|| e.key == 'Tab'
+											|| e.key == 'Delete'
+											|| e.key == 'Del'
+											|| (e.key >= 0 && e.key <= 9))
+									) {
+										e.preventDefault();     // Prevent character input
+										e.stopPropagation();
+									}
+								} catch (ex) {
+									if( !(e.keyCode == 8                                // backspace key
+											|| e.keyCode == 9							// tab key
+											|| e.keyCode == 46                          // delete key
+											|| (e.keyCode >= 48 && e.keyCode <= 57)     // numbers on keyboard
+											|| (e.keyCode >= 96 && e.keyCode <= 105))   // number on keypad
+									) {
+										e.preventDefault();     // Prevent character input
+										e.stopPropagation();
+
+									}
+								}
 							}
 
 						 this.settings.keydown(e);


### PR DESCRIPTION
There are keyboard layouts which enter digits using unusual keycodes, for example, Lithuanian, where digits are put in the AltGr layer.

This makes the input filter check the KeyboardEvent.key property instead of KeyboardEvent.keyCode (which is left as a fallback).