### PR TITLE
Detect iPad Pro as a touchscreen device

### DIFF
--- a/js/bootstrap-pincode-input.js
+++ b/js/bootstrap-pincode-input.js
@@ -280,6 +280,10 @@
 			if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
 				return true;
 			}
+			// iPad Pro pretends to be a Mac, but Macs don't have touch controls
+			if (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1) {
+				return true;
+			}
 		},
 		_addEventsToInput: function (input, inputnumber) {
 


### PR DESCRIPTION
iPad Pro mimics Safari on a Mac and doesn't have "iPad" in the user agent. I added detection code that relies on the fact that iPads are multitouch devices and Macs aren't.