### PR TITLE
[Touch mode] Place digits more precisely in the middle of fake boxes

### DIFF
--- a/js/bootstrap-pincode-input.js
+++ b/js/bootstrap-pincode-input.js
@@ -32,7 +32,7 @@
 		inputtype: 'number',
 		inputmode: 'numeric',
 		inputclass: '',									// could be changed to form-control-lg or any other class
-		letterspacingfix: 2.8,							// this value could be changed when the digits are not completely visible in touch device mode		
+		characterwidth: null, 		// em width of PIN character; defaults to 0.54 (em width of a typical digit), or 0.4 if digits are hidden
 		keydown: function (e) {
 		},
 		change: function (input, value, inputnumber) {		// callback on every input on change (keyup event)
@@ -142,11 +142,16 @@
 
 				// calculate letter-spacing in Javascript since this isn't possible in CSS
 				var inputs = this.settings.inputs;
-				var letterspacingfix = this.settings.letterspacingfix;
+				var digitEms = this.settings.characterwidth || (this.settings.hidedigits ? 0.4 : 0.54);
 				setTimeout(function(){
-					var width = $(input).innerWidth() - ((inputs + letterspacingfix) * inputs);
-					var spacing = (width / inputs) ;
-					$(input).css({"letter-spacing":spacing + "px"});
+					var digitWidth = parseFloat(getComputedStyle(input.get(0)).fontSize) * digitEms;
+					var spaceWidth = input.innerWidth() / inputs;
+					var spaceBetweenChars = spaceWidth - digitWidth;
+					$(input).css({
+						"padding-left": spaceBetweenChars / 2 + "px",
+						"padding-right": "0",
+						"letter-spacing": spaceBetweenChars + "px"
+					});
 				},0);
 
 				


### PR DESCRIPTION
I was noticing that the digits were off to one side when viewed on mobile. I'm not quite sure how the "letterspacingfix" worked, but it seemed to rely on a "magic number" of 2.8 which I guess wasn't working so well for me. I refactored it to set the letter-spacing and padding-left based on the actual character size, which is calculated from the element. Only "magic number" left is the width of the character in ems, but that shouldn't be *too* varied (and I added a config var just in case one wants to customize it). Digit placement seems much more centered now on mobile, at least for me. See what you think!